### PR TITLE
chore: Add build status and code coverage badges

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ categories = [
 license = "Apache-2.0"
 
 [badges]
+codecov = { repository = "indiv0/conductor-rs", branch = "master", service = "github" }
 maintenance = { status = "actively-developed" }
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # conductor-rs
 
+[![Build Status](https://img.shields.io/azure-devops/build/indiv0/7dbcf843-e4bb-4c6d-8e6d-2dbeb5ca3b6b/5)](https://dev.azure.com/indiv0/conductor-rs/_build?definitionId=5)
+[![Coverage](https://img.shields.io/codecov/c/gh/indiv0/conductor-rs?token=c43247f3bba945dd804aa263991dae8babc123def456)](https://codecov.io/gh/indiv0/conductor-rs)
+
 Conductor-rs is a high level Conductor library for Rust.
 
 The crate is called `conductor` and you can depend on it via Cargo:


### PR DESCRIPTION
Add an Azure Pipelines build status badge.
Add a Codecov code coverage badge.