### PR TITLE
docs(lib.rs): Add `#[doc(html_root_url = "...")]`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![deny(unsafe_code)]
+#![doc(html_root_url = "https://docs.rs/conductor/0.1.0")]
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Add the `#[doc(html_root_url = "...")]` attribute pointing to the
docs.rs documentation for the latest release of conductor-rs. Closes #7.