### PR TITLE
chore(Makefile): Add Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,28 @@
+CLIPPY_LINTS = -W clippy::all -W clippy::pedantic -W clippy::restriction -W clippy::nursery
+
+all: check clippy test doc
+.PHONY: all bench check clean clippy doc fmt test watch
+
+bench:
+	cargo bench
+
+check:
+	cargo check
+
+clean:
+	cargo clean
+
+clippy:
+	cargo clippy -- $(CLIPPY_LINTS)
+
+doc:
+	cargo doc
+
+fmt:
+	cargo fmt
+
+test:
+	cargo test
+
+watch:
+	cargo watch -s make


### PR DESCRIPTION
Add a makefile to simplify the development process by providing make
directives for complex tasks (e.g., `make clippy` to run clippy with all
the desired links).