### PR TITLE
test: Add an HTML root URL test

### DIFF
--- a/tests/version-numbers.rs
+++ b/tests/version-numbers.rs
@@ -2,3 +2,8 @@
 fn test_readme_deps() {
     version_sync::assert_markdown_deps_updated!("README.md");
 }
+
+#[test]
+fn test_html_root_url() {
+    version_sync::assert_html_root_url_updated!("src/lib.rs");
+}


### PR DESCRIPTION
Add an integration test to verify that the HTML root URL doc attribute
always points to the version of Conductor specified in the `Cargo.toml`.

Closes #6.