### PR TITLE
Add a TaskDef struct

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,5 +29,19 @@ license = "Apache-2.0"
 codecov = { repository = "indiv0/conductor-rs", branch = "master", service = "github" }
 maintenance = { status = "actively-developed" }
 
+[dependencies]
+serde = { version = "1.0.99", features = ["derive"] }
+serde_json = "1.0.40"
+
 [dev-dependencies]
+criterion = "0.3.0"
+matches = "0.1.8"
 version-sync = "0.8.1"
+
+[[example]]
+name = "task_def"
+path = "examples/task_def.rs"
+
+[[bench]]
+name = "task"
+harness = false

--- a/benches/task.rs
+++ b/benches/task.rs
@@ -1,0 +1,40 @@
+// Copyright 2018 Netflix, Inc.
+// Copyright 2019 Nikita Pekin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use conductor::TaskDef;
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+fn bench_simple(c: &mut Criterion) {
+    let mut group = c.benchmark_group("TaskDef group");
+
+    group.bench_function("TaskDef::new", |b| {
+        b.iter(|| TaskDef::new(black_box("eat_spam".to_string())))
+    });
+
+    let task_def = TaskDef::new("eat_spam".to_string());
+    group.bench_function("TaskDef Serialize", |b| {
+        b.iter(|| serde_json::to_string(black_box(&task_def)).expect("serialized"))
+    });
+
+    let json = serde_json::to_string(&task_def).expect("serialized");
+    group.bench_function("TaskDef Deserialize", |b| {
+        b.iter(|| serde_json::from_str::<TaskDef>(black_box(&json)))
+    });
+
+    group.finish()
+}
+
+criterion_group!(benches, bench_simple);
+criterion_main!(benches);

--- a/examples/task_def.rs
+++ b/examples/task_def.rs
@@ -1,0 +1,21 @@
+// Copyright 2018 Netflix, Inc.
+// Copyright 2019 Nikita Pekin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use conductor::TaskDef;
+
+fn main() {
+    let task_def = TaskDef::new("eat_spam".to_string());
+    println!("Task definition: {:#?}", task_def);
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,160 @@
+// Copyright 2018 Netflix, Inc.
+// Copyright 2019 Nikita Pekin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::error::Error as StdError;
+use std::fmt;
+
+/// Wrapper around `std::Result`.
+pub type Result<T> = std::result::Result<T, Error>;
+
+type Source = Box<dyn StdError + Send + Sync>;
+
+/// Represents errors that can occur while performing Conductor API operations.
+pub struct Error {
+    kind: Kind,
+    source: Option<Source>,
+}
+
+#[derive(Debug)]
+pub(crate) enum Kind {
+    /// A `serde_json::Error` that occurred while (de)serializing JSON.
+    Json,
+}
+
+impl Error {
+    fn new(kind: Kind) -> Self {
+        Self { kind, source: None }
+    }
+
+    fn with<S: Into<Source>>(mut self, source: S) -> Self {
+        self.source = Some(source.into());
+        self
+    }
+}
+
+impl fmt::Debug for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut f = f.debug_tuple("Error");
+        f.field(&self.kind);
+        if let Some(ref source) = self.source {
+            f.field(source);
+        }
+        f.finish()
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if let Some(ref source) = self.source {
+            write!(f, "{}: {}", self.description(), source)
+        } else {
+            f.write_str(self.description())
+        }
+    }
+}
+
+impl StdError for Error {
+    fn description(&self) -> &str {
+        match self.kind {
+            Kind::Json => "JSON error",
+        }
+    }
+
+    #[allow(trivial_casts)]
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        self.source
+            .as_ref()
+            .map(|source| &**source as &(dyn StdError + 'static))
+    }
+}
+
+impl From<serde_json::Error> for Error {
+    fn from(err: serde_json::Error) -> Self {
+        Self::new(Kind::Json).with(err)
+    }
+}
+
+#[doc(hidden)]
+trait AssertSendSync: Send + Sync + 'static {}
+#[doc(hidden)]
+impl AssertSendSync for Error {}
+
+#[cfg(test)]
+mod tests {
+    use crate::error::{Error, Kind};
+    use matches::assert_matches;
+    use std::error::Error as StdError;
+    use std::io;
+
+    #[test]
+    fn when_new_error_then_kind_field_set() {
+        let err = Error::new(Kind::Json);
+        assert_matches!(err.kind, Kind::Json);
+    }
+
+    #[test]
+    fn when_new_error_then_source_is_none() {
+        let err = Error::new(Kind::Json);
+        assert!(err.source.is_none());
+    }
+
+    #[test]
+    fn given_error_with_kind_when_debug_fmt_then_print_tuple_with_kind() {
+        let err = Error::new(Kind::Json);
+        let string = format!("{:?}", err);
+        assert_eq!(string, "Error(Json)");
+    }
+
+    #[test]
+    fn given_error_with_kind_when_display_fmt_then_print_description() {
+        let err = Error::new(Kind::Json);
+        let string = format!("{}", err);
+        assert_eq!(string, "JSON error");
+    }
+
+    #[test]
+    fn given_error_with_source_when_debug_fmt_then_print_tuple_with_source() {
+        let err = Error::new(Kind::Json).with(new_io_error());
+        let string = format!("{:?}", err);
+        assert_eq!(
+            string,
+            "Error(Json, Custom { kind: Other, error: \"oh no!\" })"
+        );
+    }
+
+    #[test]
+    fn given_error_with_source_when_display_fmt_then_print_description_with_source() {
+        let err = Error::new(Kind::Json).with(new_io_error());
+        let string = format!("{}", err);
+        assert_eq!(string, "JSON error: oh no!");
+    }
+
+    #[test]
+    fn given_error_with_no_source_when_get_source_then_return_none() {
+        let err = Error::new(Kind::Json);
+        assert_matches!(err.source(), None);
+    }
+
+    #[test]
+    fn given_error_with_source_when_get_source_then_return_source() {
+        let err = Error::new(Kind::Json).with(new_io_error());
+        let source = err.source();
+        assert_matches!(source, Some(source) if source.description() == "oh no!");
+    }
+
+    fn new_io_error() -> io::Error {
+        io::Error::new(io::ErrorKind::Other, "oh no!")
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! conductor-rs
+//! conductor-rs is a Netflix [Conductor](https://netflix.github.io/conductor/)
+//! client library implementation.
+//!
+//! # Quick Start
+//!
+//! To execute a workflow, you need a [`TaskDef`] for each task in your
+//! workflow:
+//! ```rust
+//! use conductor::TaskDef;
+//! #
+//! # fn main() {
+//! let get_spam = TaskDef::new("get_spam".to_string());
+//! let eat_spam = TaskDef::new("eat_spam".to_string());
+//! # }
+//! ```
 
 #![warn(
     anonymous_parameters,
@@ -40,8 +54,8 @@
 )]
 #![deny(rust_2018_idioms, unsafe_code)]
 
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn test() {}
-}
+mod error;
+mod task;
+
+pub use error::Result;
+pub use task::TaskDef;

--- a/src/task.rs
+++ b/src/task.rs
@@ -1,0 +1,148 @@
+// Copyright 2018 Netflix, Inc.
+// Copyright 2019 Nikita Pekin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use serde::{Deserialize, Serialize};
+
+/// Conductor task definition.
+///
+/// Task definitions define task-level parameters like keys for input and output
+/// data.
+///
+/// # Examples
+///
+/// Create a task definition:
+///
+/// ```rust
+/// use conductor::TaskDef;
+/// #
+/// # fn main() {
+/// let task_def = TaskDef::new("eat_spam".to_string());
+/// # }
+/// ```
+///
+/// Print a task's name:
+///
+/// ```rust
+/// # use conductor::TaskDef;
+/// #
+/// # fn main() {
+/// # let task_def = TaskDef::new("eat_spam".to_string());
+/// println!("Task name: {}", task_def.name());
+/// # }
+/// ```
+///
+/// # Invariants
+///
+/// * Tasks **MUST** have a unique name.
+#[derive(Debug, Deserialize, Serialize)]
+pub struct TaskDef {
+    name: String,
+}
+
+impl TaskDef {
+    /// Creates a task definition.
+    ///
+    /// This function takes an argument of type `String` and creates a task
+    /// definition with that name.
+    ///
+    /// # Examples
+    ///
+    /// Create a task definition, using a name from a program argument:
+    ///
+    /// ```rust
+    /// use conductor::TaskDef;
+    /// #
+    /// # fn main() {
+    /// if let Some(name) = std::env::args().skip(1).next() {
+    ///     let task_def = TaskDef::new(name);
+    /// }
+    /// # }
+    /// ```
+    pub fn new(name: String) -> Self {
+        Self { name }
+    }
+
+    /// Returns the task's name.
+    ///
+    /// # Examples
+    ///
+    /// Get the task's name and print it:
+    ///
+    /// ```rust
+    /// # use conductor::TaskDef;
+    /// #
+    /// # fn main() {
+    /// # let task_def = TaskDef::new("eat_spam".to_string());
+    /// println!("Task name: {}", task_def.name());
+    /// # }
+    /// ```
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Sets the task's name.
+    ///
+    /// This function takes a `String` as an argument and sets the task's name
+    /// to that value.
+    ///
+    /// # Examples
+    ///
+    /// Set a task's name and print it:
+    ///
+    /// ```rust
+    /// # use conductor::TaskDef;
+    /// #
+    /// # fn main() {
+    /// # let mut task_def = TaskDef::new("get_spam".to_string());
+    /// task_def.set_name("eat_spam".to_string());
+    /// println!("Task name: {}", task_def.name());
+    /// # }
+    pub fn set_name(&mut self, name: String) {
+        self.name = name;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::task::TaskDef;
+    use serde_json::json;
+
+    #[test]
+    fn task_def_name_gets_serialized() {
+        let task_def = TaskDef::new("eat_spam".to_string());
+        let json = serde_json::to_value(&task_def).expect("serialized");
+        assert_eq!(json["name"], "eat_spam");
+    }
+
+    #[test]
+    fn task_def_name_gets_deserialized() {
+        let json = json!({ "name": "eat_spam" });
+        let task_def: TaskDef = serde_json::from_value(json).expect("deserialized");
+        assert_eq!(task_def.name(), "eat_spam");
+    }
+
+    #[test]
+    fn get_name_returns_the_name() {
+        let task_def = TaskDef::new("get_spam".to_string());
+        assert_eq!(task_def.name(), "get_spam");
+    }
+
+    #[test]
+    fn set_name_sets_the_name() {
+        let mut task_def = TaskDef::new("get_spam".to_string());
+        task_def.set_name("eat_spam".to_string());
+        assert_eq!(task_def.name(), "eat_spam");
+    }
+}


### PR DESCRIPTION
Add a `TaskDef` struct to represent Conductor task definitions.
Currently the struct only has a name, and no other fields.  Add an
`examples/task_def.rs` to demonstrate the use of `TaskDef`.  Add the
`serde` and `serde_json` dependencies for serialization/deserialization
of the `TaskDef` struct to/from JSON.  Add a `task` benchmark for
profiling the performance of `TaskDef` operations using the `criterion`
crate.

Add an `Error` type to represent errors that can occur while performing
Conductor API operations.  Add an `error::Kind` enum which contains the
potential error kinds that can occur.  Add an `error::Result` type alias
for `std::Result`, allowing for easier error handling and simpler
function signatures.

Remove unused tests module from the crate root. There are now other
tests modules in the source files, so there is no need for an empty one
to get the CI tests to pass.